### PR TITLE
Fragments create saved objects feature

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -24,7 +24,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/org/launchcode/g7/bookcollections/BookRecyclerViewAdapter.java
+++ b/app/src/main/java/org/launchcode/g7/bookcollections/BookRecyclerViewAdapter.java
@@ -49,7 +49,7 @@ public class BookRecyclerViewAdapter extends RecyclerView.Adapter<BookRecyclerVi
                 {
                     // Notify the active callbacks interface (the activity, if the
                     // fragment is attached to one) that an item has been selected.
-                    mListener.onListFragmentInteraction(holder.mItem);
+                    mListener.onListFragmentInteraction(holder.mItem,holder.getAdapterPosition());
                 }
             }
         });

--- a/app/src/main/java/org/launchcode/g7/bookcollections/ItemListFragment.java
+++ b/app/src/main/java/org/launchcode/g7/bookcollections/ItemListFragment.java
@@ -117,6 +117,6 @@ public class ItemListFragment extends Fragment
     public interface OnListFragmentInteractionListener
     {
         // TODO: Update argument type and name
-        void onListFragmentInteraction(Object item);
+        void onListFragmentInteraction(Object item,int position);
     }
 }

--- a/app/src/main/java/org/launchcode/g7/bookcollections/MainActivity.java
+++ b/app/src/main/java/org/launchcode/g7/bookcollections/MainActivity.java
@@ -16,7 +16,9 @@ import org.launchcode.g7.bookcollections.models.Shelf;
 import java.util.ArrayList;
 import java.util.List;
 
-public class MainActivity extends AppCompatActivity implements ItemListFragment.OnListFragmentInteractionListener
+public class MainActivity extends AppCompatActivity implements
+        ItemListFragment.OnListFragmentInteractionListener,
+        NewShelfFragment.OnBuildShelfClickListener
 {
     private RecyclerView ARecyclerView;
 
@@ -43,14 +45,16 @@ public class MainActivity extends AppCompatActivity implements ItemListFragment.
                 // TODO add new collection context behavior
                 // if collections
                 // open new collection dialog
-                if(inShelfView()){
+                if (inShelfView())
+                {
                     NewShelfFragment shelfFragment = new NewShelfFragment();
-                    shelfFragment.show(getSupportFragmentManager(),"newshelfdialog");
+                    shelfFragment.show(getSupportFragmentManager(), "newshelfdialog");
                 }
                 // TODO add new book context behavior
                 // if inside collections,
                 // open new book dialog
-                else{
+                else
+                {
                     NewBookFragment bookFragment = new NewBookFragment();
                     bookFragment.show(getSupportFragmentManager(), "newbookdialog");
                 }
@@ -93,7 +97,7 @@ public class MainActivity extends AppCompatActivity implements ItemListFragment.
 
 
         // if viewing the Shelf List
-        if(inShelfView())
+        if (inShelfView())
         {
             // then item is a Shelf, so cast it as such.
             Shelf selectedShelf = (Shelf) item;
@@ -104,7 +108,34 @@ public class MainActivity extends AppCompatActivity implements ItemListFragment.
                             this));
         }
         // if viewing a Book list (i.e. inside a Shelf)
-            // show book info?
+        // show book info?
+    }
+
+    // Called when user enters a shelf name and clicks Build Shelf
+    @Override
+    public void onBuildShelfClick(Shelf newShelf)
+    {
+        // add the shelf to the file
+        addShelf(newShelf);
+    }
+
+    /**
+     * Adds one Shelf to the file.
+     * @param shelf new shelf to be appended to the file.
+     */
+    public void addShelf(Shelf shelf)
+    {
+        // get an instance of BookReadWrite
+        BookReadWrite bookReadWrite = new BookReadWrite(getApplicationContext());
+
+        // read any existing shelves
+        List<Shelf> shelvesInFile = bookReadWrite.readShelves();
+
+        // add new shelf to List of existing shelves
+        shelvesInFile.add(shelf);
+
+        // save shelves
+        bookReadWrite.saveShelves(shelvesInFile);
     }
 
     /**

--- a/app/src/main/java/org/launchcode/g7/bookcollections/MainActivity.java
+++ b/app/src/main/java/org/launchcode/g7/bookcollections/MainActivity.java
@@ -18,9 +18,11 @@ import java.util.List;
 
 public class MainActivity extends AppCompatActivity implements
         ItemListFragment.OnListFragmentInteractionListener,
-        NewShelfFragment.OnBuildShelfClickListener
+        NewShelfFragment.OnBuildShelfClickListener,
+        NewBookFragment.OnAddBookClickListener
 {
     private RecyclerView ARecyclerView;
+    private int selectedShelfIndex;
 
     @Override
     protected void onCreate(Bundle savedInstanceState)
@@ -91,7 +93,7 @@ public class MainActivity extends AppCompatActivity implements
     }
 
     @Override
-    public void onListFragmentInteraction(Object item)
+    public void onListFragmentInteraction(Object item,int position)
     {
         // get a pointer to the recyclerView
 
@@ -101,6 +103,8 @@ public class MainActivity extends AppCompatActivity implements
         {
             // then item is a Shelf, so cast it as such.
             Shelf selectedShelf = (Shelf) item;
+            // store the item's position
+            selectedShelfIndex = position;
             // swap adapter to BookAdapter
             ARecyclerView.setAdapter(
                     new BookRecyclerViewAdapter(
@@ -123,7 +127,7 @@ public class MainActivity extends AppCompatActivity implements
      * Adds one Shelf to the file.
      * @param shelf new shelf to be appended to the file.
      */
-    public void addShelf(Shelf shelf)
+    private void addShelf(Shelf shelf)
     {
         // get an instance of BookReadWrite
         BookReadWrite bookReadWrite = new BookReadWrite(getApplicationContext());
@@ -138,9 +142,41 @@ public class MainActivity extends AppCompatActivity implements
         bookReadWrite.saveShelves(shelvesInFile);
     }
 
+    @Override
+    public void onAddBookClick(Book newBook)
+    {
+        addBook(newBook);
+    }
+
+    /**
+     * Adds a book the the selectedShelf.
+     * @param book a Book object to be added to currently viewed Shelf
+     */
+    private void addBook(Book book)
+    {
+        // selectedShelf is a copy, I think, i.e. it isn't the saved version of the shelf.
+
+        // get an instance of BookReadWrite
+        BookReadWrite bookReadWrite = new BookReadWrite(getApplicationContext());
+
+        // read any existing shelves
+        List<Shelf> shelvesInFile = bookReadWrite.readShelves();
+
+        // get a pointer to the shelf that's in the file
+        Shelf shelfInFile = shelvesInFile.get(selectedShelfIndex);
+
+        // add the book to the shelf
+        shelfInFile.addBooks(book);
+
+        // save shelves
+        bookReadWrite.saveShelves(shelvesInFile);
+
+        // TODO Scrap this and make a BookReadWrite method for saving individual books to a shelf
+    }
+
     /**
      * Use when you need to test if MainActivity is currently in Shelf or Book viewing mode. While
-     * methods inside the MainActivty class don't really need this, it may be useful in case other
+     * methods inside the MainActivity class don't really need this, it may be useful in case other
      * classes need to test what mode MainActivity is in.
      *
      * @return true if currently viewing shelves. false if in book view.

--- a/app/src/main/java/org/launchcode/g7/bookcollections/MainActivity.java
+++ b/app/src/main/java/org/launchcode/g7/bookcollections/MainActivity.java
@@ -92,6 +92,7 @@ public class MainActivity extends AppCompatActivity implements
         return super.onOptionsItemSelected(item);
     }
 
+    // called whenever a user taps on a shelf or book in its list.
     @Override
     public void onListFragmentInteraction(Object item,int position)
     {
@@ -103,7 +104,7 @@ public class MainActivity extends AppCompatActivity implements
         {
             // then item is a Shelf, so cast it as such.
             Shelf selectedShelf = (Shelf) item;
-            // store the item's position
+            // store the item's position/index
             selectedShelfIndex = position;
             // swap adapter to BookAdapter
             ARecyclerView.setAdapter(
@@ -142,6 +143,7 @@ public class MainActivity extends AppCompatActivity implements
         bookReadWrite.saveShelves(shelvesInFile);
     }
 
+    // called when user clicks to add a book to the shelf.
     @Override
     public void onAddBookClick(Book newBook)
     {
@@ -149,13 +151,12 @@ public class MainActivity extends AppCompatActivity implements
     }
 
     /**
-     * Adds a book the the selectedShelf.
+     * Adds a book the the selectedShelf. Uses the selectedShelfIndex provided by
+     * onListFragmentInteraction parameters.
      * @param book a Book object to be added to currently viewed Shelf
      */
     private void addBook(Book book)
     {
-        // selectedShelf is a copy, I think, i.e. it isn't the saved version of the shelf.
-
         // get an instance of BookReadWrite
         BookReadWrite bookReadWrite = new BookReadWrite(getApplicationContext());
 
@@ -170,8 +171,6 @@ public class MainActivity extends AppCompatActivity implements
 
         // save shelves
         bookReadWrite.saveShelves(shelvesInFile);
-
-        // TODO Scrap this and make a BookReadWrite method for saving individual books to a shelf
     }
 
     /**

--- a/app/src/main/java/org/launchcode/g7/bookcollections/NewBookFragment.java
+++ b/app/src/main/java/org/launchcode/g7/bookcollections/NewBookFragment.java
@@ -1,5 +1,6 @@
 package org.launchcode.g7.bookcollections;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.DialogFragment;
@@ -9,10 +10,27 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.EditText;
 
+import org.launchcode.g7.bookcollections.models.Book;
+
 public class NewBookFragment extends DialogFragment {
     private Button addBook;
     private EditText editText;
     private String ISBN;
+    private OnAddBookClickListener onAddBookClickListener;
+
+    @Override
+    public void onAttach(Context context)
+    {
+        super.onAttach(context);
+
+        // Verify that the host context implements the OnAddBookClickListener interface
+        try {
+            onAddBookClickListener = (OnAddBookClickListener) context;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(context.toString()
+                    + " must implement OnAddBookClickListener");
+        }
+    }
 
     @Nullable
     @Override
@@ -26,6 +44,10 @@ public class NewBookFragment extends DialogFragment {
             public void onClick(View v) {
                 ISBN = editText.getText().toString();
                 //TODO do something with ISBN before removing fragment
+
+                // Send the newly created book back to the listener
+                onAddBookClickListener.onAddBookClick(new Book(ISBN));
+
                 removeSelf();
             }
         };
@@ -36,5 +58,14 @@ public class NewBookFragment extends DialogFragment {
 
     private void removeSelf() {
         getActivity().getSupportFragmentManager().beginTransaction().remove(this).commit();
+    }
+    /**
+     * Requiring this interface means that the activity that uses this fragment must also be able
+     * to listen for the clicks from the submit button of this fragment. Listening to those click
+     * events will allow the host activity to pull the information from the text boxes.
+     */
+    public interface OnAddBookClickListener
+    {
+        void onAddBookClick(Book newBook);
     }
 }

--- a/app/src/main/java/org/launchcode/g7/bookcollections/NewShelfFragment.java
+++ b/app/src/main/java/org/launchcode/g7/bookcollections/NewShelfFragment.java
@@ -46,7 +46,7 @@ public class NewShelfFragment extends DialogFragment {
     {
         super.onAttach(context);
 
-        // Verify that the host context implements the onBuildShelfClickListener interface
+        // Verify that the host context implements the OnBuildShelfClickListener interface
         try {
             onBuildShelfClickListener = (OnBuildShelfClickListener) context;
         } catch (ClassCastException e) {

--- a/app/src/main/java/org/launchcode/g7/bookcollections/NewShelfFragment.java
+++ b/app/src/main/java/org/launchcode/g7/bookcollections/NewShelfFragment.java
@@ -1,5 +1,6 @@
 package org.launchcode.g7.bookcollections;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.DialogFragment;
@@ -15,6 +16,7 @@ public class NewShelfFragment extends DialogFragment {
     private Button buildShelf;
     private EditText shelfEdit;
     private String shelfName;
+    private OnBuildShelfClickListener onBuildShelfClickListener;
 
     @Nullable
     @Override
@@ -27,6 +29,9 @@ public class NewShelfFragment extends DialogFragment {
             @Override
             public void onClick(View v) {
                 shelfName = shelfEdit.getText().toString();
+
+                onBuildShelfClickListener.onBuildShelfClick(new Shelf(shelfName));
+
                 createNewShelf();
                 removeSelf();
             }
@@ -36,6 +41,20 @@ public class NewShelfFragment extends DialogFragment {
         return view;
     }
 
+    @Override
+    public void onAttach(Context context)
+    {
+        super.onAttach(context);
+
+        // Verify that the host context implements the onBuildShelfClickListener interface
+        try {
+            onBuildShelfClickListener = (OnBuildShelfClickListener) context;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(context.toString()
+                    + " must implement OnHeadlineSelectedListener");
+        }
+    }
+
     private void createNewShelf() {
         Shelf shelf = new Shelf(shelfName);
         //TODO add this shelf to the list of shelves and save it to file
@@ -43,5 +62,15 @@ public class NewShelfFragment extends DialogFragment {
 
     private void removeSelf() {
         getActivity().getSupportFragmentManager().beginTransaction().remove(this).commit();
+    }
+
+    /**
+     * Requiring this interface means that the activity that uses this fragment must also be able
+     * to listen for the clicks from the submit button of this fragment. Listening to those click
+     * events will allow the host activity to pull the information from the text boxes.
+     */
+    public interface OnBuildShelfClickListener
+    {
+        void onBuildShelfClick(Shelf newShelf);
     }
 }

--- a/app/src/main/java/org/launchcode/g7/bookcollections/ShelfRecyclerViewAdapter.java
+++ b/app/src/main/java/org/launchcode/g7/bookcollections/ShelfRecyclerViewAdapter.java
@@ -37,7 +37,7 @@ public class ShelfRecyclerViewAdapter extends RecyclerView.Adapter<ShelfRecycler
     }
 
     @Override
-    public void onBindViewHolder(final ViewHolder holder, int position)
+    public void onBindViewHolder(final ViewHolder holder, final int position)
     {
         holder.mItem = mValues.get(position);
         holder.mIdView.setText(mValues.get(position).getName());
@@ -52,7 +52,7 @@ public class ShelfRecyclerViewAdapter extends RecyclerView.Adapter<ShelfRecycler
                 {
                     // Notify the active callbacks interface (the activity, if the
                     // fragment is attached to one) that an item has been selected.
-                    mListener.onListFragmentInteraction(holder.mItem);
+                    mListener.onListFragmentInteraction(holder.mItem,holder.getAdapterPosition());
                 }
             }
         });

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
         
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.1.1'
         
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Feb 15 20:00:14 PST 2018
+#Thu Mar 29 00:47:05 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
What changed: 
1) I modified the fragments' listeners and events to hand information to MainActivity. 
2) I added methods to MainActivity that are called by those listeners in order to add Shelf and Book objects to the saved file. 
3) Some Gradle files were modified as a byproduct of updating Android Studio.

Why: The goal of this feature branch was to enable NewShelfFragment and NewBookFragment to actually create the new shelves and books that they promise. To do that, our MainActivity needed the textbox info that those fragments obtain. The main way that fragments are supposed to communicate info back to their host activity is through event parameters and listeners.

Related issues: #1 User can create a new collection, #2 User can add a book by entering text